### PR TITLE
👷build: use custom runc/containerd versions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -21,6 +21,8 @@ jobs:
     outputs:
       output_ubuntu_2204: ${{ steps.build.outputs.output_ubuntu_2204 }}
       output_ubuntu_2404: ${{ steps.build.outputs.output_ubuntu_2404 }}
+      runc_version: ${{ steps.build.outputs.runc_version }}
+      containerd_version: ${{ steps.build.outputs.containerd_version }}
     strategy:
         matrix:
             REGION: ["us-east-2", "eu-west-2", "cloudgouv-eu-west-1"]
@@ -45,25 +47,37 @@ jobs:
     - name: 📦 Build image
       id: build
       run: |
+        set -ex
         cd image-builder/images/capi
         useradd imagebuilder
         sed -i 's/"type": "ansible"/"type": "ansible","user":"imagebuilder"/' packer/outscale/packer.json
+        KUBERNETES_VERSION=`echo $KUBERNETES_VERSION | cut -d / -f 1`
         SERIES=`echo $KUBERNETES_VERSION | sed 's/\(v1.[1-9][0-9]\).*$/\1/'`
         DEB=`echo $KUBERNETES_VERSION | sed 's/v//'`
         date=${{ needs.date.outputs.date }}
         omi_name=${{ matrix.TARGET }}-kubernetes-$KUBERNETES_VERSION-$date
         source_ip=`curl https://api.ipify.org`
-        export PACKER_FLAGS="--var kubernetes_semver=$KUBERNETES_VERSION --var kubernetes_series=$SERIES --var kubernetes_deb_version=$DEB-1.1 --var overwrite_existing=true --var omi_name=$omi_name --var ssh_source_cidr=$source_ip/32"
+        if [ -z "$RUNC_VERSION" ]; then
+          RUNC_VERSION=`jq -r .runc_version packer/config/containerd.json`
+        fi
+        if [ -z "$CONTAINERD_VERSION" ]; then
+          CONTAINERD_VERSION=`jq -r .containerd_version packer/config/containerd.json`
+        fi
+        export PACKER_FLAGS="--var runc_version=$RUNC_VERSION --var containerd_version=$CONTAINERD_VERSION --var kubernetes_semver=$KUBERNETES_VERSION --var kubernetes_series=$SERIES --var kubernetes_deb_version=$DEB-1.1 --var overwrite_existing=true --var omi_name=$omi_name --var ssh_source_cidr=$source_ip/32"
         make build-osc-${{ matrix.TARGET }}
         target=`echo ${{ matrix.TARGET }} | sed 's/-/_/g'`
-        echo "output_$target=$omi_name" >> "$GITHUB_OUTPUT"
+        echo "output_$target=$omi_name" >> $GITHUB_OUTPUT
         echo "IMAGE_NAME=$omi_name" >> $GITHUB_ENV
+        echo "runc_version=$RUNC_VERSION" >> $GITHUB_OUTPUT
+        echo "containerd_version=$CONTAINERD_VERSION" >> $GITHUB_OUTPUT
       env:
         KUBERNETES_VERSION: ${{ github.ref_name }}
         OSC_ACCESS_KEY: ${{ secrets.OSC_ACCESS_KEY }}
         OSC_SECRET_KEY: ${{ secrets.OSC_SECRET_KEY }}
         OSC_REGION: ${{ matrix.REGION }}
         OSC_ACCOUNT_ID: ${{ secrets.OSC_ACCOUNT_ID }}
+        RUNC_VERSION: ${{ vars.RUNC_VERSION}}
+        CONTAINERD_VERSION: ${{ vars.CONTAINERD_VERSION}}
     - name: 🧹 Frieza
       uses: outscale/frieza-github-actions/frieza-clean@master
       with:
@@ -94,6 +108,8 @@ jobs:
       env:
         IMAGE_UBUNTU_2204: ${{ needs.build.outputs.output_ubuntu_2204 }}
         IMAGE_UBUNTU_2404: ${{ needs.build.outputs.output_ubuntu_2404 }}
+        RUNC_VERSION: ${{ needs.build.outputs.runc_version }}
+        CONTAINERD_VERSION: ${{ needs.build.outputs.containerd_version }}
       with:
         github-token: "${{ secrets.RELEASE_GITHUB_TOKEN }}"
         retries: 3
@@ -102,7 +118,7 @@ jobs:
             await github.rest.repos.createRelease({
               draft: false,
               name: "Kubernetes "+process.env.GITHUB_REF_NAME,
-              body: "New images: \n* "+process.env.IMAGE_UBUNTU_2204+"\n* "+process.env.IMAGE_UBUNTU_2404,
+              body: "runc: "+process.env.RUNC_VERSION+" containerd: "+process.env.CONTAINERD_VERSION+\nNew images:\n* "+process.env.IMAGE_UBUNTU_2204+"\n* "+process.env.IMAGE_UBUNTU_2404,
               owner: context.repo.owner,
               prerelease: false,
               repo: context.repo.repo,

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
 
 - [Overview](#-overview)
 - [List of images](#-list-of-images)
+- [Releasing new images](#-releasing-new-images)
 - [License](#-license)
 - [Contributing](#-contributing)
 
@@ -40,6 +41,29 @@ The images are produced by an open-source builder. There is no guarantee that cl
 See releases.
 
 For each version of Kubernetes, 2 images are built: one based on Ubuntu 22.04, one based on Ubuntu 24.04.
+
+---
+
+## 🚀 Releasing new images
+
+The runc version is defined by the RUNC_VERSION variable.
+The containerd version is defined by the CONTAINERD_VERSION variable.
+
+New images are built when a new tag is pushed. The tag name defines the Kubernetes version to use.
+
+```shell
+export RELEASE_TAG=v1.33.6
+git tag -s ${RELEASE_TAG} -m "🔖 Kubernetes ${RELEASE_TAG}"
+git push origin ${RELEASE_TAG}
+```
+
+When re-releasing a previously released Kubernetes version, a `/[some additional comment]` suffix can be added to the tag, it will be ignored.
+
+```shell
+export RELEASE_TAG=v1.33.6/runc-1.2.6
+git tag -s ${RELEASE_TAG} -m "🔖 Kubernetes ${RELEASE_TAG}"
+git push origin ${RELEASE_TAG}
+```
 
 ---
 


### PR DESCRIPTION
# 📦 Pull Request Template

## Description

This PR parses the tag for runc/containerd versions.

There is currently a [bug in image-builder](https://github.com/kubernetes-sigs/image-builder/pull/1880) preventing the user to change the runc version installed. This PR will be merged when the bug is fixed.

## Type of Change

Please check the relevant option(s):

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🧹 Code cleanup or refactor
- [ ] 📝 Documentation update
- [x] 🔧 Build or CI-related change
- [ ] 🔒 Security fix
- [ ] Other (specify):

## How Has This Been Tested?

Please describe the test strategy:

- [x] Manual testing
- [ ] Unit tests
- [ ] Integration tests
- [ ] Not tested yet

## Checklist

* [x] I have followed the [Contributing Guidelines](CONTRIBUTING.md)
* [x] I have added tests or explained why they are not needed
* [x] I have updated relevant documentation (README, examples, etc.)
* [x] My changes follow the [Conventional Commits](https://www.conventionalcommits.org/) specification
* [x] My commits include appropriate [Gitmoji](https://gitmoji.dev/)

## Additional Context
