### PR TITLE
👷 build: / is not a valid separator

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -51,7 +51,7 @@ jobs:
         cd image-builder/images/capi
         useradd imagebuilder
         sed -i 's/"type": "ansible"/"type": "ansible","user":"imagebuilder"/' packer/outscale/packer.json
-        KUBERNETES_VERSION=`echo $KUBERNETES_VERSION | cut -d / -f 1`
+        KUBERNETES_VERSION=`echo $KUBERNETES_VERSION | cut -d - -f 1`
         SERIES=`echo $KUBERNETES_VERSION | sed 's/\(v1.[1-9][0-9]\).*$/\1/'`
         DEB=`echo $KUBERNETES_VERSION | sed 's/v//'`
         date=${{ needs.date.outputs.date }}
@@ -118,7 +118,7 @@ jobs:
             await github.rest.repos.createRelease({
               draft: false,
               name: "Kubernetes "+process.env.GITHUB_REF_NAME,
-              body: "runc: "+process.env.RUNC_VERSION+" containerd: "+process.env.CONTAINERD_VERSION+\nNew images:\n* "+process.env.IMAGE_UBUNTU_2204+"\n* "+process.env.IMAGE_UBUNTU_2404,
+              body: "runc: "+process.env.RUNC_VERSION+"\ncontainerd: "+process.env.CONTAINERD_VERSION+"\n\nNew images:\n* "+process.env.IMAGE_UBUNTU_2204+"\n* "+process.env.IMAGE_UBUNTU_2404,
               owner: context.repo.owner,
               prerelease: false,
               repo: context.repo.repo,


### PR DESCRIPTION
## Description

A "vx.y.z/runc-vx.y.z" tag cannot be created if a "vx.y.z" tag exists. We need to use a different separator.

Also add a missing "

## Type of Change

Please check the relevant option(s):

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🧹 Code cleanup or refactor
- [ ] 📝 Documentation update
- [x] 🔧 Build or CI-related change
- [ ] 🔒 Security fix
- [ ] Other (specify):

## How Has This Been Tested?

Please describe the test strategy:

- [x] Manual testing
- [ ] Unit tests
- [ ] Integration tests
- [ ] Not tested yet

## Checklist

* [x] I have followed the [Contributing Guidelines](CONTRIBUTING.md)
* [x] I have added tests or explained why they are not needed
* [x] I have updated relevant documentation (README, examples, etc.)
* [x] My changes follow the [Conventional Commits](https://www.conventionalcommits.org/) specification
* [x] My commits include appropriate [Gitmoji](https://gitmoji.dev/)

## Additional Context
